### PR TITLE
Inserted the Google Analytics (GA4) ID under our site setting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,4 +57,4 @@ is_government: false
 facebook-pixel: ""
 google_analytics: ""
 linkedin-insights: ""
-google_analytics_ga4: ""
+google_analytics_ga4: G-D6GJDHES2T


### PR DESCRIPTION
Hi Jeanne

I've set-up a Google Analytics account for our ELIS website and inserted the measurement ID (G-D6GJDHES2T) within our 'Isomer Site Settings' page. As per the Isomer guide, after I raise a Pull Request and you approved this, I should be able to see the reports on my GA4 platform. We can test out next week! 
